### PR TITLE
New targetDir config key to define were to create the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ package is put there before packaging. The default is `dist/`. The package file 
         "groupId"      : "com.example",    // required - the Maven group id.
         "artifactId"   : "{name}",         // the Maven artifact id.
         "buildDir"     : "dist",           // project build directory.
+        "targetDir"    : "dist",           // were to create the target package.
         "finalName"    : "{name}",         // the final name of the file created when the built project is packaged.
         "type"         : "war",            // type of package. "war" or "jar" supported.
         "fileEncoding" : "utf-8"           // file encoding when traversing the file system, default is UTF-8

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ var validateConfig, validateRepos, validateRepo, userConfig;
 const DEFAULT_CONFIG = {
     artifactId: '{name}',
     buildDir: 'dist',
+    targetDir: 'dist',
     finalName: '{name}',
     type: 'war',
     fileEncoding: 'utf-8',
@@ -24,6 +25,7 @@ validateConfig = defineOpts({
     artifactId    : '?|string - the Maven artifact id. default "' + DEFAULT_CONFIG.artifactId + '".',
     classifier    : '?|string - the Maven optional classifier.',
     buildDir      : '?|string - build directory. default "' + DEFAULT_CONFIG.buildDir + '".',
+    targetDir     : '?|string - were to create built artifact. default "' + DEFAULT_CONFIG.targetDir + '".',
     finalName     : '?|string - the final name of the file created when the built project is packaged. default "' +
                     DEFAULT_CONFIG.finalName + '"',
     type          : '?|string - "jar" or "war". default "' + DEFAULT_CONFIG.type + '".',
@@ -66,7 +68,7 @@ function filterConfig (configTmpl, pkg) {
 
 function archivePath (isSnapshot) {
     var conf = getConfig(isSnapshot);
-    return path.join(conf.buildDir, conf.finalName + '.' + conf.type);
+    return path.join(conf.targetDir, conf.finalName + '.' + conf.type);
 }
 
 function mvnArgs (repoId, isSnapshot) {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "coveralls": "^2.11.2",
     "finn-js-code-style": "4.3.0",
     "istanbul": "0.3.14",
-    "mocha": "2.2.5",
+    "mocha": "2.3.3",
     "mocha-lcov-reporter": "0.0.2",
-    "mock-fs": "2.7.0",
+    "mock-fs": "3.5.0",
     "proxyquire": "1.5.0",
     "sinon": "1.14.1"
   }


### PR DESCRIPTION
It allows you to create the target package in a different directory than the default one.

By default, it has the same value as 'buildDir'
